### PR TITLE
Remove pr-annotate job from workflow

### DIFF
--- a/.github/workflows/check-uncovered-folders.yml
+++ b/.github/workflows/check-uncovered-folders.yml
@@ -156,44 +156,6 @@ jobs:
             git branch -D "$branch" || true
           done
 
-  pr-annotate:
-    name: Annotate PR with missing language suggestions
-    runs-on: ubuntu-latest
-    if: github.event_name == 'pull_request'
-    steps:
-      - uses: actions/checkout@v4
-      - name: Compute missing languages
-        id: compute_missing
-        run: |
-          exclude_pattern='^(.github$|bin$|obj$|node_modules$|\.vscode$|tests?$|dist$|docs$)'
-          mapfile -t all_folders < <(ls -d */ 2>/dev/null | sed 's#/##' | grep -Ev "$exclude_pattern" || true)
-          mapfile -t tested_langs < <(ls .github/workflows/test-*.yml 2>/dev/null | sed -E 's#.*/test-(.*)\.yml#\1#' || true)
-          tested_folders=()
-          for lang in "${tested_langs[@]}"; do
-            case "$lang" in
-              java) tested_folders+=("java-maven") ;;
-              node) tested_folders+=("node-express" "react-vite") ;;
-              python) tested_folders+=("python-package" "flask-app" "fastapi") ;;
-              *) tested_folders+=("$lang") ;;
-            esac
-          done
-          missing=()
-          for f in "${all_folders[@]}"; do
-            if [[ ! " ${tested_folders[@]} " =~ " ${f} " ]]; then
-              missing+=("$f")
-            fi
-          done
-          printf '%s\n' "${missing[@]}" | jq -R -s -c 'split("\n")[:-1]' > missing.json || true
-          missing_json=$(cat missing.json || echo '[]')
-          echo "missing=$missing_json" >> $GITHUB_OUTPUT
-          # If the branch contains a .badge-pr.json file, expose it as output so the commenter can use it
-          if [ -f .badge-pr.json ]; then
-            prnum=$(jq -r '.pr // empty' .badge-pr.json || true)
-            if [ -n "$prnum" ]; then
-              echo "badge_pr=$prnum" >> $GITHUB_OUTPUT
-            fi
-          fi
-
       - name: Comment on PR with suggestions
         uses: actions/github-script@v6
         env:


### PR DESCRIPTION
Removed the 'pr-annotate' job from the workflow that annotated PRs with missing language suggestions.